### PR TITLE
Add basic auth in CURL header instead of using it in URL

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,6 +27,8 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('url')->end()
                         ->scalarNode('login')->end()
                         ->scalarNode('password')->end()
+                        ->scalarNode('auth_basic_user')->end()
+                        ->scalarNode('auth_basic_pass')->end()
                     ->end()
                 ->end()
             ->end()

--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ fidesio_isidore:
         login: api_login # Isidore login
         password: api_password # Isidore api password
         auth_basic_user: auth_basic_user # Application Basic Authorization `user` if needed
-        auth_basic_user: auth_basic_user # Application Basic Authorization `password` if needed
+        auth_basic_pass: auth_basic_pass # Application Basic Authorization `password` if needed
 ```

--- a/README.md
+++ b/README.md
@@ -42,5 +42,7 @@ fidesio_isidore:
     client:
         url: http://url.to.isidore.app # Isidore URL
         login: api_login # Isidore login
-        password: api_paasword # Isidore api password
+        password: api_password # Isidore api password
+        auth_basic_user: auth_basic_user # Application Basic Authorization `user` if needed
+        auth_basic_user: auth_basic_user # Application Basic Authorization `password` if needed
 ```

--- a/Services/Client.php
+++ b/Services/Client.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface,
 class Client
 {
     protected $baseURL;
+    protected $authBasicUser;
+    protected $authBasicPass;
     protected $stores = array();
     protected $lastRequest = null;
     protected $lastResponse = null;
@@ -42,6 +44,8 @@ class Client
         $this->container = $container;
         $this->logger = $logger;
         $this->baseURL = $this->container->getParameter('fidesio_isidore.client.url');
+        $this->authBasicUser = $this->container->getParameter('fidesio_isidore.client.auth_basic_user');
+        $this->authBasicPass = $this->container->getParameter('fidesio_isidore.client.auth_basic_pass');
         $this->debug = $this->container->getParameter('kernel.debug');
     }
 
@@ -115,6 +119,38 @@ class Client
     }
 
     /**
+     * @return string
+     */
+    public function getAuthBasicUser()
+    {
+        return $this->authBasicUser;
+    }
+
+    /**
+     * @param string $authBasicUser
+     */
+    public function setAuthBasicUser($authBasicUser)
+    {
+        $this->authBasicUser = $authBasicUser;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAuthBasicPass()
+    {
+        return $this->authBasicPass;
+    }
+
+    /**
+     * @param string $authBasicPass
+     */
+    public function setAuthBasicPass($authBasicPass)
+    {
+        $this->authBasicPass = $authBasicPass;
+    }
+
+    /**
      * @param $url
      * @param array $getData
      * @param array $postData
@@ -150,6 +186,9 @@ class Client
             CURLINFO_HEADER_OUT => true,
             CURLOPT_HEADER => true,
         ));
+        if(!empty($this->getBasicAuthUser()) && !empty($this->getBasicAuthUser())) {
+            curl_setopt($ch, CURLOPT_USERPWD, $this->getBasicAuthUser() . ":" . $this->getBasicAuthPass());
+        }
 
         if(!empty($postData))
             curl_setopt_array($ch, array(
@@ -186,6 +225,7 @@ class Client
             $this->logger->critical($message);
             if($this->debug) {
                 dump($info);
+                curl_close($ch);
                 throw new Exception($message);
             }
         }


### PR DESCRIPTION
Lorsqu'un site est protégé par le HTTP Basic authentification certains appels au Webservice ne fonctionne pas à cause de la signature qui n'est pas correcte. Cette proposition devrait corriger le problème
