### PR TITLE
Fix search not working when using spaces in the parameters

### DIFF
--- a/Services/Client.php
+++ b/Services/Client.php
@@ -265,7 +265,7 @@ class Client
         $queryURL = $url2;
 
         if(!empty($getData))
-            $queryURL .= '?' . http_build_query($getData, '', '&');
+            $queryURL .= '?' . http_build_query($getData, '', '&', PHP_QUERY_RFC3986);
 
         if($authService->getTokenName() !== null && $authService->getTokenDelimiter() !== null && $authService->getUuid() !== null){
             $getData[$authService->getTokenName()] = $authService->getUuid();
@@ -285,7 +285,7 @@ class Client
 
             }
 
-            $queryURL = $url . '?' . http_build_query($getData, '', '&');
+            $queryURL = $url . '?' . http_build_query($getData, '', '&', PHP_QUERY_RFC3986);
         }
 
         $url = $queryURL;


### PR DESCRIPTION
Cette modification est pour prendre en compte les espaces dans les paramètres des requêtes lorsqu'on fait une recherche. Par défaut PHP convertit les espaces en "+" alors qu'il faudrait que ça soit convertit en "%20" pour que le framework puisse avoir les bonnes valeurs sinon il retourne "null"
